### PR TITLE
Changed order of support checking

### DIFF
--- a/src/support.rs
+++ b/src/support.rs
@@ -30,10 +30,10 @@ impl Protocol {
     pub fn choose(options: &Options) -> Self {
         if let Some(protocol) = options.protocol {
             protocol
-        } else if Protocol::support_kitty() {
-            Protocol::Kitty
         } else if Protocol::support_iterm() {
             Protocol::Iterm
+        } else if Protocol::support_kitty() {
+            Protocol::Kitty
         } else if Protocol::support_sixel() {
             Protocol::Sixel
         } else {


### PR DESCRIPTION
Tested both kitty and iTerm protocols and found that iTerm protocol works better in Wezterm.